### PR TITLE
Fix hardcoded NID file path

### DIFF
--- a/ps4_module.py
+++ b/ps4_module.py
@@ -995,7 +995,8 @@ def load_file(f, neflags, format):
     bitness = ps4.procomp('metapc', CM_N64 | CM_M_NN | CM_CC_FASTCALL, 'ps4_errno_700')
     
     # Load Aerolib...
-    nids = load_nids(idc.idadir() + '/loaders/aerolib.csv')
+    nids_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'aerolib.csv')
+    nids = load_nids(nids_path)
     
     # Segment Loading...
     for segm in ps4.E_SEGMENTS:


### PR DESCRIPTION
Previously aerolib.csv was loaded from idc.idadir()/loaders/aerolib.csv 
which failed on systems where the file lives in the user's IDA profile 
directory (e.g. ~/.idapro/loaders/)

Changes:
- Load aerolib.csv relative to the loader script using __file__ so placing 
  aerolib.csv alongside ps4_module.py is sufficient regardless of OS or IDA 
  install location

I'm on macOS using IDA Pro 9.3 which is how encountered these errors. 